### PR TITLE
Upgrade Ruff to 0.16.0

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,16 @@
+name: Ruff
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v9.0.0
+      - run: uvx ruff@0.16.0 check .

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,4 @@
+required-version = "==0.16.0"
+
+[lint]
+ignore = ["EXE001"]

--- a/scripts/check_install_boundary.py
+++ b/scripts/check_install_boundary.py
@@ -66,9 +66,7 @@ def bad_files(skill_dir: Path) -> list[Path]:
     bad: list[Path] = []
     for path in skill_dir.rglob("*"):
         rel_parts = path.relative_to(skill_dir).parts
-        if any(part in BANNED_DIR_NAMES for part in rel_parts):
-            bad.append(path)
-        elif path.is_file() and (path.suffix in BANNED_FILE_SUFFIXES or path.name in BANNED_FILE_NAMES):
+        if any(part in BANNED_DIR_NAMES for part in rel_parts) or path.is_file() and (path.suffix in BANNED_FILE_SUFFIXES or path.name in BANNED_FILE_NAMES):
             bad.append(path)
     return bad
 


### PR DESCRIPTION
## Summary

- Pin Ruff to exactly 0.16.0 with required-version.
- Apply the expanded Ruff defaults to the repository Python install-boundary helper.
- Fix the safe findings and document narrow compatibility exceptions.
- Add a dedicated GitHub Actions lint gate using setup-uv v9.

## Why

Ruff 0.16 enables 413 rules by default, up from 59. Pinning prevents surprise toolchain drift while adopting those stronger checks intentionally.

## Testing

- uvx ruff@0.16.0 check .
- install boundary and Python compilation

## Risk

Low. Changes are lint-driven cleanups plus CI and configuration. Repository-specific exceptions are explicit in ruff.toml, and no runtime behaviour change is intended.